### PR TITLE
added cx_sy_itab_line_not_found

### DIFF
--- a/src/cx_sy_itab_line_not_found.abap
+++ b/src/cx_sy_itab_line_not_found.abap
@@ -1,0 +1,28 @@
+CLASS cx_sy_itab_line_not_found DEFINITION
+  PUBLIC
+  INHERITING FROM cx_sy_itab_error
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    CONSTANTS cx_sy_itab_line_not_found TYPE c LENGTH 32 VALUE 'E61F13F7B4071ED1B9A737CCF34D481F' ##NO_TEXT.
+    CONSTANTS index_access TYPE c LENGTH 32 VALUE 'E61F13F7B4071ED1B9A75B2C4EA78821' ##NO_TEXT.
+    CONSTANTS key_access TYPE c LENGTH 32 VALUE 'E61F13F7B4071ED1B9A75CD438968821' ##NO_TEXT.
+    CONSTANTS free_key_access TYPE c LENGTH 32 VALUE '4635000000311EE5B1D392AE4164EE86' ##NO_TEXT.
+    DATA index TYPE i VALUE 0 ##NO_TEXT.
+    DATA key_name TYPE string.
+    DATA key_comp_values TYPE string.
+
+    METHODS constructor
+    IMPORTING
+      !textid LIKE textid OPTIONAL
+      !previous LIKE previous OPTIONAL
+      !index TYPE i DEFAULT 0
+      !key_name TYPE string OPTIONAL
+      !key_comp_values TYPE string OPTIONAL.
+  PROTECTED SECTION.
+ENDCLASS.
+
+CLASS cx_sy_itab_line_not_found IMPLEMENTATION.
+ENDCLASS.


### PR DESCRIPTION
I switched the static code check for the abap2UI5-downport to 2305-api-intersect-702, to make sure that the linter checks against v.702 APIs.
https://github.com/abap2UI5/abap2UI5-downport/commit/f1a9686c18c822806f62b5290e99645882f5327c

But I get errors now:
https://github.com/abap2UI5/abap2UI5-downport/runs/20269791002

As far as i know cx_sy_itab_line_not_found does exist in v.702 so i added the class in this PR.

I hope i do everything right here :)